### PR TITLE
fix for gotoLabel error

### DIFF
--- a/demos/test.html
+++ b/demos/test.html
@@ -17,7 +17,7 @@
 	<td>x</td>
 </tr>
 <tr>
-	<td>gotolabel</td>
+	<td>gotoLabel</td>
 	<td>target1</td>
 	<td></td>
 </tr>


### PR DESCRIPTION
In Selenium 1.10.0 (and Firefox 17), there's a little gotoLabel error. this fixes it. 
